### PR TITLE
Fix spacer css selector

### DIFF
--- a/weatherornot@somepaulo.github.io/stylesheet.css
+++ b/weatherornot@somepaulo.github.io/stylesheet.css
@@ -1,4 +1,4 @@
-.spacer-pill * {
+.weatherornot-spacer * {
   color: transparent;
 }
 


### PR DESCRIPTION
The spacer css selector had class equal to `spacer-pill`, while `weatherornot-spacer` class was actually applied. This resulted in spacer being visible.