### PR TITLE
Don't hardcode the icon size

### DIFF
--- a/weatherornot@somepaulo.github.io/extension.js
+++ b/weatherornot@somepaulo.github.io/extension.js
@@ -134,7 +134,6 @@ const WeatherIndicator = GObject.registerClass(
             this._weatherUpdateDebounceTimer = null;
       
             this._icon = new St.Icon({
-                icon_size: 16,
                 y_align: Clutter.ActorAlign.CENTER,
                 style_class: 'system-status-icon',
             });


### PR DESCRIPTION
When fractional scaling is used, the weather icon remains small, and does not follow the size of other status icons. The already defined 'system-status-icon' class ensures that the size is correct.