### PR TITLE
Use activateApp() to open Weather app

### DIFF
--- a/weatherornot@somepaulo.github.io/extension.js
+++ b/weatherornot@somepaulo.github.io/extension.js
@@ -48,7 +48,7 @@ export default class WeatherOrNotExtension extends Extension {
         if (!_indicator) {
             _indicator = new WeatherIndicator(weather, networkIcon);
             _indicator.add_style_class_name('weatherornot');
-            _indicator.connect('button-press-event', () => GLib.spawn_command_line_async('gapplication launch org.gnome.Weather'));
+            _indicator.connect('button-press-event', () => weather.activateApp());
         }
 
         if (!_spacer) {


### PR DESCRIPTION
This fixes the problem that a new instance of the app is opened every time when the user clicks on the button. If Weather app is already opened, activate it instead of launching a new instance.